### PR TITLE
Empty adt

### DIFF
--- a/R/ADTnorm.R
+++ b/R/ADTnorm.R
@@ -86,8 +86,14 @@ ADTnorm = function(cell_x_adt = NULL, cell_x_feature = NULL, save_outpath = NULL
         stop("Please specify the peak type to be either 'mode' or 'midpoint'.")
     }
 
+    ## Remove ADT with zero counts
+    col_sums <- colSums(cell_x_adt)
+    if (any(col_sums == 0)){
+        message("Markers with zero counts will be ignored")
+        cell_x_adt = cell_x_adt[, col_sums > 0, drop = FALSE] 
+    }
+    
     ## preprocess the input data
-    cell_x_adt = cell_x_adt[, colSums(cell_x_adt) > 0, drop = FALSE] ## Remove ADT with zero counts
     cell_x_adt = arcsinh_transform(cell_x_adt = cell_x_adt) ## Arcsinh transformation
     all_marker_name = colnames(cell_x_adt) ## save the original marker name
     if(!is.factor(cell_x_feature$sample)){

--- a/R/ADTnorm.R
+++ b/R/ADTnorm.R
@@ -87,6 +87,7 @@ ADTnorm = function(cell_x_adt = NULL, cell_x_feature = NULL, save_outpath = NULL
     }
 
     ## preprocess the input data
+    cell_x_adt = cell_x_adt[, colSums(cell_x_adt) > 0, drop = FALSE] ## Remove ADT with zero counts
     cell_x_adt = arcsinh_transform(cell_x_adt = cell_x_adt) ## Arcsinh transformation
     all_marker_name = colnames(cell_x_adt) ## save the original marker name
     if(!is.factor(cell_x_feature$sample)){

--- a/R/get_peak_midpoint.R
+++ b/R/get_peak_midpoint.R
@@ -368,7 +368,7 @@ get_peak_midpoint = function(cell_x_adt = NULL, cell_x_feature = NULL, adt_marke
     ## initiate landmark to record peak mode location
     landmark = matrix(NA, ncol = peak_num, nrow = length(sample_name_list))
     landmarkRegion = list()
-    for (i in seq_along(peak_num)) {
+    for (i in seq_len(peak_num)) {
         landmarkRegion[[i]] = matrix(NA, ncol = 2, nrow = length(sample_name_list))
         rownames(landmarkRegion[[i]]) = sample_name_list
     }

--- a/R/get_peak_midpoint.R
+++ b/R/get_peak_midpoint.R
@@ -26,8 +26,15 @@
 #' }
 # require(flowStats)
 # require(dplyr)
-get_peak_midpoint = function(cell_x_adt = NULL, cell_x_feature = NULL, adt_marker_select = NULL, adt_marker_index = NULL, bwFac_smallest = 1.1, bimodal_marker_index = NULL, trimodal_marker_index = NULL, positive_peak = NULL, neg_candidate_thres = asinh(10/5 + 1), lower_peak_thres = 0.001, cd3_index = NULL, cd4_index = NULL, cd8_index = NULL) {
+get_peak_midpoint = function(cell_x_adt = NULL, cell_x_feature = NULL, adt_marker_select = NULL, adt_marker_index = NULL,
+                             bwFac_smallest = 1.1, bimodal_marker_index = NULL, trimodal_marker_index = NULL,
+                             positive_peak = NULL, neg_candidate_thres = asinh(10/5 + 1), lower_peak_thres = 0.001,
+                             cd3_index = NULL, cd4_index = NULL, cd8_index = NULL) {
 
+    if (length(adt_marker_select) > 1){
+        stop("adt_marker_select should be a single marker name")
+    }
+    
     ## set parameters
     bwFac = 1.2
     border = 0.01
@@ -361,7 +368,7 @@ get_peak_midpoint = function(cell_x_adt = NULL, cell_x_feature = NULL, adt_marke
     ## initiate landmark to record peak mode location
     landmark = matrix(NA, ncol = peak_num, nrow = length(sample_name_list))
     landmarkRegion = list()
-    for (i in 1:peak_num) {
+    for (i in seq_along(peak_num)) {
         landmarkRegion[[i]] = matrix(NA, ncol = 2, nrow = length(sample_name_list))
         rownames(landmarkRegion[[i]]) = sample_name_list
     }

--- a/R/plot_adt_density_each.R
+++ b/R/plot_adt_density_each.R
@@ -41,6 +41,9 @@ plot_adt_density_each = function(adt_count, cell_x_feature, brewer_palettes, par
     # valley_landmark_list = parameter_list$valley_landmark_list
     # brewer_palettes = parameter_list$brewer_palettes
 
+    # If there is no batch, add a dummy variable
+    if (! "batch" %in% colnames(cell_x_feature)){ cell_x_feature$batch <- 1 }
+    
     tmpProfile = data.frame(counts = adt_count) %>%
         mutate(
             sample = rep(cell_x_feature$sample, 1),

--- a/R/plot_adt_density_with_peak_valley.R
+++ b/R/plot_adt_density_with_peak_valley.R
@@ -49,6 +49,10 @@ plot_adt_density_with_peak_valley = function(cell_x_adt, cell_x_feature, adt_mar
     if(is.null(adt_marker_select)){
         adt_marker_select = colnames(cell_x_adt)
     }
+    
+    # If there is no batch, add a dummy variable
+    if (! "batch" %in% colnames(cell_x_feature)){ cell_x_feature$batch <- 1 }
+    
     tmpProfile = cell_x_adt %>% data.frame %>%
         dplyr::select(all_of(adt_marker_select)) %>%
         data.frame() %>%

--- a/R/plot_adt_density_with_peak_valley_each.R
+++ b/R/plot_adt_density_with_peak_valley_each.R
@@ -44,7 +44,10 @@ plot_adt_density_with_peak_valley_each = function(adt_count, cell_x_feature, pea
     # peak_landmark_list = parameter_list$peak_landmark_list
     # valley_landmark_list = parameter_list$valley_landmark_list
     # brewer_palettes = parameter_list$brewer_palettes
-
+  
+    # If there is no batch, add a dummy variable
+    if (! "batch" %in% colnames(cell_x_feature)){ cell_x_feature$batch <- 1 }
+      
     tmpProfile = data.frame(counts = adt_count) %>%
         mutate(
             sample = rep(cell_x_feature$sample, 1),


### PR DESCRIPTION
Hello, I ran into an error running ADTnorm on public data which has all zeroes for the isotype control columns.  It's probably not a common situation but doesn't take many changes to avoid.

This pull request:
- removes ADT columns with zero counts with a message that they will be ignored
- adds a dummy variable for "batch" to the column data table if it is missing before plotting 
- Adds a check for multiple markers to get_peak_midpoint()
- Changes 1:peak_num to seq_len(peak_num) to avoid an indexing error if peak_num is zero (this is where the original error occurred)