### PR TITLE
fix adt_marker_select subset when using quantile_clip

### DIFF
--- a/R/ADTnorm.R
+++ b/R/ADTnorm.R
@@ -215,12 +215,12 @@ ADTnorm = function(cell_x_adt = NULL, cell_x_feature = NULL, save_outpath = NULL
 
 
         if(quantile_clip < 1){ 
-            quant = quantile(cell_x_adt[[adt_marker_select]], quantile_clip, na.rm = TRUE)
+            quant = quantile(cell_x_adt[,adt_marker_select], quantile_clip, na.rm = TRUE)
             if(verbose){
                 print(paste0("Performing quantile clip to remove outliers beyond the claimed quantile ", quantile_clip, ":", quant, "......"))
             }
             
-            cell_x_adt[[adt_marker_select]][which(cell_x_adt[[adt_marker_select]] > quant)] <- NA
+            cell_x_adt[,adt_marker_select][which(cell_x_adt[,adt_marker_select] > quant)] <- NA
         }
         
         ## smallest bw for density curve


### PR DESCRIPTION
Hi, 
When `quantile_clip` is set to non-default (<1), there is a problem with the way that `cell_x_adt` is subset. As far as I understand, it is a matrix but is subset like a list, leading to 

```
Error in `*tmp*`[[adt_marker_select]] : subscript out of bounds
```
